### PR TITLE
Various script and layout fixes in doc

### DIFF
--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -15,9 +15,29 @@ export ORCA_WF_REV= # Set this variable correctly
 
 cd /path/to/orca
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
+
 nix develop --command mdbook build
-if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" "$ORCA_WF_AS_MD" > "/tmp/${ORCA_WF_TITLE}_with_commit.md" && \
- nix develop --command md-to-html "/tmp/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" | sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "/tmp/${ORCA_WF_TITLE}.html" && rm "/tmp/${ORCA_WF_TITLE}_with_commit.md" && command ls "/tmp/${ORCA_WF_TITLE}.html" >&2; fi; fi
+
+if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
+ if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else \
+ if test -z $ORCA_WF_AS_MD; then echo "ERROR: no ORCA_WF_AS_MD set">&2; false; else \
+  SANITY_CHECKS_OK=true; fi; fi; fi
+
+unset TMP_OUTPUT_DIR;TMP_OUTPUT_DIR=$(mktemp -p ~ -d)
+
+test -n $SANITY_CHECKS_OK && \
+ sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" \
+     -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" \
+     -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" \
+   "$ORCA_WF_AS_MD" > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" && \
+
+nix develop --command md-to-html "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" | \
+ sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" && \
+ rm "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md"
+
+command mv "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html" && \
+ command ls "/tmp/${ORCA_WF_TITLE}.html" && \
+ rm -rf "${TMP_OUTPUT_DIR}" && unset TMP_OUTPUT_DIR
 ```
 
 # How to sign the OR.C.A workflow document
@@ -32,8 +52,10 @@ First, we need to set an environment variable specifying the workflow we are wor
 The editor can now sign the document inline using the signing key in their own hardware token:
 ```bash
 export GPG_HW_TOKEN_KEY_ID=$(gpg --card-status | sed -n -E -e 's/^[^:]*sign[^:]*:[[:blank:]]*((:?[[:xdigit:]]{4}[[:blank:]]*){10})/\1/pi')
-sed -e '/^<!-- @GPG@SIGNATURES@ --><pre>$/q' "/tmp/${ORCA_WF_TITLE}.html" | gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > /tmp/${ORCA_WF_TITLE}.html.sig.asc && \
- cat "/tmp/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html.sig.asc" > "/tmp/${ORCA_WF_TITLE}_signed.html" && rm "/tmp/${ORCA_WF_TITLE}.html.sig.asc"
+sed -e '/^<!-- @GPG@SIGNATURES@ --><pre>$/q' "/tmp/${ORCA_WF_TITLE}.html" | \
+ gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > /tmp/${ORCA_WF_TITLE}.html.sig.asc && \
+ cat "/tmp/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html.sig.asc" > "/tmp/${ORCA_WF_TITLE}_signed.html" && \
+ rm "/tmp/${ORCA_WF_TITLE}.html.sig.asc"
 ```
 
 > [!Note]  

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -2,18 +2,31 @@
 
 At first, before selecting the commit at which the OR.C.A document is signed, **please make sure both the author and verifier's hardware token's public GPG keys** are in this repo's directory `/src/signatory_keys`. These will be required when verifying the signatures in the future.
 
-First, we need to set an environment variable specifying the workflow we want to generate:
-* For IN65: `export ORCA_WF_AS_MD="book/markdown/IN/65/IN65-ceremonie-d-ouverture-de-la-pki-offline-preprod-d-entreprise.md" && export ORCA_WF_TITLE="IN65"`
-* For IN69: `export ORCA_WF_AS_MD="book/markdown/IN/69/IN69-verifications-recurrentes-de-la-pki.md" && export ORCA_WF_TITLE="IN69"`
-
-We will now insert the commit in the OR.C.A workflow document, and transform it into a self-standing html file for the subsequent signature process.
-
+First, we need to select the document we want to generate:
+* For IN65:
 ```bash
-git checkout <commit>
+export ORCA_WF_AS_MD="book/markdown/IN/65/IN65-ceremonie-d-ouverture-de-la-pki-offline-preprod-d-entreprise.md"
+export ORCA_WF_TITLE="IN65"
+```
 
-export ORCA_WF_REV= # Set this variable correctly
+* For IN69:
+```bash
+export ORCA_WF_AS_MD="book/markdown/IN/69/IN69-verifications-recurrentes-de-la-pki.md"
+export ORCA_WF_TITLE="IN69"
+```
 
-cd /path/to/orca
+We will now insert the commit in the OR.C.A workflow document:
+```bash
+cd /path/to/orca # Please adapt to the path where you cloned OR.C.A
+git checkout <commit> # Replace with the commit or branch you want to use
+export ORCA_WF_REV=<rev> # Set this variable correctly, eg: 'A' or '1.1'
+```
+
+> [!Warning]  
+> You'll have to adapt each line above to your setup
+
+We now generate the workflow document as a self-standing file for the subsequent signature process.
+```bash
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
 export GIT_CURRENT_HASH=$(git log --pretty=format:'%H' -n 1)
 

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -22,9 +22,6 @@ git checkout <commit> # Replace with the commit or branch you want to use
 export ORCA_WF_REV=<rev> # Set this variable correctly, eg: 'A' or '1.1'
 ```
 
-> [!Warning]  
-> You'll have to adapt each line above to your setup
-
 And finally, let's generate the workflow document as a self-standing file for the subsequent signature process.
 ```bash
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -16,7 +16,8 @@ export ORCA_WF_REV= # Set this variable correctly
 cd /path/to/orca
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
 export GIT_CURRENT_HASH=$(git log --pretty=format:'%H' -n 1)
-unset SANITY_CHECKS_OK;nix develop --command mdbook build
+
+unset SANITY_CHECKS_OK
 
 if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
  if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else \
@@ -27,6 +28,7 @@ if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
 
 unset TMP_OUTPUT_DIR;TMP_OUTPUT_DIR=$(mktemp -p ~ -d)
 
+nix develop --command mdbook build
 test -n $SANITY_CHECKS_OK && \
  sed -e "s|\@ORCA\@commit\@|${GIT_CURRENT_HASH}|g" \
      -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" \

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -15,18 +15,20 @@ export ORCA_WF_REV= # Set this variable correctly
 
 cd /path/to/orca
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
-
+export GIT_CURRENT_HASH=$(git log --pretty=format:'%H' -n 1)
 unset SANITY_CHECKS_OK;nix develop --command mdbook build
 
 if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
  if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else \
  if test -z $ORCA_WF_AS_MD; then echo "ERROR: no ORCA_WF_AS_MD set">&2; false; else \
-  SANITY_CHECKS_OK=true; fi; fi; fi
+ if test -z $GIT_CURRENT_HASH; then echo "ERROR: no GIT_CURRENT_HASH set">&2; false; else \
+ if test -z $GIT_REMOTE_URL; then echo "ERROR: no GIT_REMOTE_URL set">&2; false; else \
+  SANITY_CHECKS_OK=true; fi; fi; fi; fi; fi
 
 unset TMP_OUTPUT_DIR;TMP_OUTPUT_DIR=$(mktemp -p ~ -d)
 
 test -n $SANITY_CHECKS_OK && \
- sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" \
+ sed -e "s|\@ORCA\@commit\@|${GIT_CURRENT_HASH}|g" \
      -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" \
      -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" \
    "$ORCA_WF_AS_MD" > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md"

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -16,7 +16,7 @@ export ORCA_WF_REV= # Set this variable correctly
 cd /path/to/orca
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
 
-nix develop --command mdbook build
+unset SANITY_CHECKS_OK;nix develop --command mdbook build
 
 if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
  if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else \
@@ -29,7 +29,7 @@ test -n $SANITY_CHECKS_OK && \
  sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" \
      -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" \
      -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" \
-   "$ORCA_WF_AS_MD" > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" && \
+   "$ORCA_WF_AS_MD" > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md"
 
 nix develop --command md-to-html "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" | \
  sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" && \

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -15,7 +15,7 @@ export ORCA_WF_AS_MD="book/markdown/IN/69/IN69-verifications-recurrentes-de-la-p
 export ORCA_WF_TITLE="IN69"
 ```
 
-We will now insert the commit in the OR.C.A workflow document:
+Next, let's setup our environment:
 ```bash
 cd /path/to/orca # Please adapt to the path where you cloned OR.C.A
 git checkout <commit> # Replace with the commit or branch you want to use
@@ -25,7 +25,7 @@ export ORCA_WF_REV=<rev> # Set this variable correctly, eg: 'A' or '1.1'
 > [!Warning]  
 > You'll have to adapt each line above to your setup
 
-We now generate the workflow document as a self-standing file for the subsequent signature process.
+And finally, let's generate the workflow document as a self-standing file for the subsequent signature process.
 ```bash
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
 export GIT_CURRENT_HASH=$(git log --pretty=format:'%H' -n 1)

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -16,7 +16,7 @@ export ORCA_WF_REV= # Set this variable correctly
 cd /path/to/orca
 export GIT_REMOTE_URL=$(git remote -v | sed -n -E -e 's|^.*git@(.+):(.+)\.git.*|https://\1/\2|p' -e '1q')
 nix develop --command mdbook build
-if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else if test -z ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" "$ORCA_WF_AS_MD" > "/tmp/${ORCA_WF_TITLE}_with_commit.md" && \
+if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else sed -e "s|\@ORCA\@commit\@|$(git log --pretty=format:'%H' -n 1)|g" -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" "$ORCA_WF_AS_MD" > "/tmp/${ORCA_WF_TITLE}_with_commit.md" && \
  nix develop --command md-to-html "/tmp/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" | sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "/tmp/${ORCA_WF_TITLE}.html" && rm "/tmp/${ORCA_WF_TITLE}_with_commit.md" && command ls "/tmp/${ORCA_WF_TITLE}.html" >&2; fi; fi
 ```
 

--- a/docs/IN/common/html_gen_and_signature.md
+++ b/docs/IN/common/html_gen_and_signature.md
@@ -19,28 +19,28 @@ export GIT_CURRENT_HASH=$(git log --pretty=format:'%H' -n 1)
 
 unset SANITY_CHECKS_OK
 
-if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else \
- if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else \
- if test -z $ORCA_WF_AS_MD; then echo "ERROR: no ORCA_WF_AS_MD set">&2; false; else \
- if test -z $GIT_CURRENT_HASH; then echo "ERROR: no GIT_CURRENT_HASH set">&2; false; else \
- if test -z $GIT_REMOTE_URL; then echo "ERROR: no GIT_REMOTE_URL set">&2; false; else \
+if test -z $ORCA_WF_REV; then echo "ERROR: no ORCA_WF_REV set">&2; false; else\
+ if test -z $ORCA_WF_TITLE; then echo "ERROR: no ORCA_WF_TITLE set">&2; false; else\
+ if test -z $ORCA_WF_AS_MD; then echo "ERROR: no ORCA_WF_AS_MD set">&2; false; else\
+ if test -z $GIT_CURRENT_HASH; then echo "ERROR: no GIT_CURRENT_HASH set">&2; false; else\
+ if test -z $GIT_REMOTE_URL; then echo "ERROR: no GIT_REMOTE_URL set">&2; false; else\
   SANITY_CHECKS_OK=true; fi; fi; fi; fi; fi
 
 unset TMP_OUTPUT_DIR;TMP_OUTPUT_DIR=$(mktemp -p ~ -d)
 
 nix develop --command mdbook build
-test -n $SANITY_CHECKS_OK && \
- sed -e "s|\@ORCA\@commit\@|${GIT_CURRENT_HASH}|g" \
-     -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g" \
-     -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g" \
+test -n $SANITY_CHECKS_OK &&\
+ sed -e "s|\@ORCA\@commit\@|${GIT_CURRENT_HASH}|g"\
+     -e "s|\@ORCA\@gitremote\@|${GIT_REMOTE_URL}|g"\
+     -e "s|\@ORCA\@rev\@|${ORCA_WF_REV}|g"\
    "$ORCA_WF_AS_MD" > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md"
 
-nix develop --command md-to-html "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" | \
- sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" && \
+nix develop --command md-to-html "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md" "${ORCA_WF_TITLE} rev${ORCA_WF_REV}" |\
+ sed -e '$a<hr>\n<!-- @GPG@SIGNATURES@ --><pre>' > "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" &&\
  rm "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}_with_commit.md"
 
-command mv "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html" && \
- command ls "/tmp/${ORCA_WF_TITLE}.html" && \
+command mv "${TMP_OUTPUT_DIR}/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html" &&\
+ command ls "/tmp/${ORCA_WF_TITLE}.html" &&\
  rm -rf "${TMP_OUTPUT_DIR}" && unset TMP_OUTPUT_DIR
 ```
 
@@ -56,9 +56,9 @@ First, we need to set an environment variable specifying the workflow we are wor
 The editor can now sign the document inline using the signing key in their own hardware token:
 ```bash
 export GPG_HW_TOKEN_KEY_ID=$(gpg --card-status | sed -n -E -e 's/^[^:]*sign[^:]*:[[:blank:]]*((:?[[:xdigit:]]{4}[[:blank:]]*){10})/\1/pi')
-sed -e '/^<!-- @GPG@SIGNATURES@ --><pre>$/q' "/tmp/${ORCA_WF_TITLE}.html" | \
- gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > /tmp/${ORCA_WF_TITLE}.html.sig.asc && \
- cat "/tmp/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html.sig.asc" > "/tmp/${ORCA_WF_TITLE}_signed.html" && \
+sed -e '/^<!-- @GPG@SIGNATURES@ --><pre>$/q' "/tmp/${ORCA_WF_TITLE}.html" |\
+ gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > /tmp/${ORCA_WF_TITLE}.html.sig.asc &&\
+ cat "/tmp/${ORCA_WF_TITLE}.html" "/tmp/${ORCA_WF_TITLE}.html.sig.asc" > "/tmp/${ORCA_WF_TITLE}_signed.html" &&\
  rm "/tmp/${ORCA_WF_TITLE}.html.sig.asc"
 ```
 

--- a/docs/offline/verifying_last_ceremony_report.md
+++ b/docs/offline/verifying_last_ceremony_report.md
@@ -14,9 +14,9 @@ Get the name of the reporter, observer and operator that were running the last c
 ```bash
 export TMP_GPG_HOME=$(mktemp -d)
 gpg --home="$TMP_GPG_HOME" --import /path/to/src/share_holders_keys/env/*
-gpg --home="$TMP_GPG_HOME" --list-keys --keyid-format LONG --with-colons | \
- sed -n -e '/^pub/{n;p}' | \
- sed -n -E 's/^fpr:([^:]*:){8}([^:]*).*$/\2:6:/p' | \
+gpg --home="$TMP_GPG_HOME" --list-keys --keyid-format LONG --with-colons |\
+ sed -n -e '/^pub/{n;p}' |\
+ sed -n -E 's/^fpr:([^:]*:){8}([^:]*).*$/\2:6:/p' |\
  gpg --home="$TMP_GPG_HOME" --import-ownertrust
 ```
 
@@ -27,7 +27,7 @@ export REPORT_UNSIGNED=$(mktemp -u)
 export REPORT_SIGNATURES=$(mktemp -u)
 sed -e '1,/^@GPG@SIGNATURES@$/ d' "$REPORT" > "$REPORT_SIGNATURES"
 sed -e '/^@GPG@SIGNATURES@$/q' "$REPORT" > "$REPORT_UNSIGNED"
-gpg --home="$TMP_GPG_HOME" --verify "$REPORT_SIGNATURES" "$REPORT_UNSIGNED" && \
+gpg --home="$TMP_GPG_HOME" --verify "$REPORT_SIGNATURES" "$REPORT_UNSIGNED" &&\
  echo "All signatures verified"
 ```
 

--- a/docs/offline/verifying_last_ceremony_report.md
+++ b/docs/offline/verifying_last_ceremony_report.md
@@ -14,7 +14,10 @@ Get the name of the reporter, observer and operator that were running the last c
 ```bash
 export TMP_GPG_HOME=$(mktemp -d)
 gpg --home="$TMP_GPG_HOME" --import /path/to/src/share_holders_keys/env/*
-gpg --home="$TMP_GPG_HOME" --list-keys --keyid-format LONG --with-colons | sed -n -e '/^pub/{n;p}' | sed -n -E 's/^fpr:([^:]*:){8}([^:]*).*$/\2:6:/p' | gpg --home="$TMP_GPG_HOME" --import-ownertrust
+gpg --home="$TMP_GPG_HOME" --list-keys --keyid-format LONG --with-colons | \
+ sed -n -e '/^pub/{n;p}' | \
+ sed -n -E 's/^fpr:([^:]*:){8}([^:]*).*$/\2:6:/p' | \
+ gpg --home="$TMP_GPG_HOME" --import-ownertrust
 ```
 
 With the environment variable `TMP_GPG_HOME` set above, verify each detached signature of the previous IN65 with:
@@ -24,7 +27,8 @@ export REPORT_UNSIGNED=$(mktemp -u)
 export REPORT_SIGNATURES=$(mktemp -u)
 sed -e '1,/^@GPG@SIGNATURES@$/ d' "$REPORT" > "$REPORT_SIGNATURES"
 sed -e '/^@GPG@SIGNATURES@$/q' "$REPORT" > "$REPORT_UNSIGNED"
-gpg --home="$TMP_GPG_HOME" --verify "$REPORT_SIGNATURES" "$REPORT_UNSIGNED" && echo "All signatures verified"
+gpg --home="$TMP_GPG_HOME" --verify "$REPORT_SIGNATURES" "$REPORT_UNSIGNED" && \
+ echo "All signatures verified"
 ```
 
 An example of what you should get (correct signature):

--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -181,7 +181,7 @@ For the rest of the procedure below, you can consider references to 👥`team me
 
 ```report
 Name of the organiser:
-................................................................................
+...............................................................................
 
 Revision of the ceremony workflow used:
 @ORCA@rev@
@@ -190,51 +190,51 @@ Version (commit) of the workflow document:
 @ORCA@commit@
 
 Names of the team members that participate to the ceremony:
-Operator: ......................................................................
-Reporter: ......................................................................
-Observer: ......................................................................
-These 3 roles are handled by 3 different people .............. PASS [] / FAIL []
-These 3 people are located in the same physical room ......... PASS [] / FAIL []
+Operator: .....................................................................
+Reporter: .....................................................................
+Observer: .....................................................................
+These 3 roles are handled by 3 different people ............. PASS [] / FAIL []
+These 3 people are located in the same physical room ........ PASS [] / FAIL []
 
 Date of the ceremony:
-................................................................................
+...............................................................................
 
 Target environment:
-........................................................... preprod [] / prod []
+.......................................................... preprod [] / prod []
 Trusted commit for the new ceremony:
-................................................................................
+...............................................................................
 
 Date of the previous ceremony:
-................................................................................
+...............................................................................
 Previous trusted commit (as read from the previous ceremony's report):
-................................................................................
+...............................................................................
 Previous backup sha256 checksum (as read from the previous ceremony's report):
-................................................................................
+...............................................................................
 
 The ceremony's workflow document (valid rev, signatures) have been checked by:
-the operator ................................................. PASS [] / FAIL []
-the reporter ................................................. PASS [] / FAIL []
+the operator ................................................ PASS [] / FAIL []
+the reporter ................................................ PASS [] / FAIL []
 
 The previous ceremony's report signatures have been verified by:
-the operator ................................................ PASS [] / FAIL* []
-the reporter ................................................ PASS [] / FAIL* []
+the operator ............................................... PASS [] / FAIL* []
+the reporter ............................................... PASS [] / FAIL* []
 
 The verifiable bytes of the iso are (value of *Niso*):
-................................................................................
+...............................................................................
 The sha256 checksum of the *N* verifiable bytes is (value of *Ciso*):
-................................................................................
+...............................................................................
 
 The review of changes/content of the bootable live media has been performed by:
-the operator ................................................. PASS [] / FAIL []
-the reporter ................................................. PASS [] / FAIL []
-All (possible) changes are legitimate ........................ PASS [] / FAIL []
+the operator ................................................ PASS [] / FAIL []
+the reporter ................................................ PASS [] / FAIL []
+All (possible) changes are legitimate ....................... PASS [] / FAIL []
 
-A bootable live media has been generated for this ceremony ... PASS [] / FAIL []
+A bootable live media has been generated for this ceremony .. PASS [] / FAIL []
 Identity of the team member who brings the bootable media (the key owner):
-.............................................. the operator [] / the reporter []
+............................................. the operator [] / the reporter []
 
 The offline CA private data has been restored from the following archive file:
-................................................................................
+...............................................................................
 ```
 
 </td></table>
@@ -276,20 +276,20 @@ When booting *ephemeral vault*, a NixOS logo will appear with a boot menu mentio
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The key with the vault iso image is set as read only ......... PASS [] / FAIL []
+The key with the vault iso image is set as read only ........ PASS [] / FAIL []
 
 The operator's machine:
-can select the key as boot device ............................ PASS [] / FAIL []
-can successfully complete boot on the readonly key ..........  PASS [] / FAIL []
+can select the key as boot device ........................... PASS [] / FAIL []
+can successfully complete boot on the readonly key .......... PASS [] / FAIL []
 
 While performing the USB key content check on the operator's machine:
-the first partition is the only one marked as bootable ....... PASS [] / FAIL []
-the checksum *Ciso* is correct ............................... PASS [] / FAIL []
-the computer has been powered off while the key was still read-only ............
-.............................................................. PASS [] / FAIL []
+the first partition is the only one marked as bootable ...... PASS [] / FAIL []
+the checksum *Ciso* is correct .............................. PASS [] / FAIL []
+the computer has been powered off while the key was still read-only ...........
+............................................................. PASS [] / FAIL []
 
-The key for the ephemeral vault is then set as read/write and the ephemeral ....
-vault is immediately booted .................................. PASS [] / FAIL []
+The key for the ephemeral vault is then set as read/write and the ephemeral ...
+vault is immediately booted ................................. PASS [] / FAIL []
 ```
 
 </td></table>
@@ -311,11 +311,11 @@ Before the very first shell prompt after booting, that computed checksum is disp
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data checksum displayed at boot (_Cvault_) matches the .......
-previous ceremony's backup sha256 checksum .................. PASS [] / FAIL* []
-0 token exists in the vault private data at startup .......... PASS [] / FAIL []
-The vault service status returns "Initialized" = true ....... PASS [] / FAIL* []
-The vault service status returns "Sealed" = true ............. PASS [] / FAIL []
+The vault private data checksum displayed at boot (_Cvault_) matches the ......
+previous ceremony's backup sha256 checksum ................. PASS [] / FAIL* []
+0 token exists in the vault private data at startup ......... PASS [] / FAIL []
+The vault service status returns "Initialized" = true ...... PASS [] / FAIL* []
+The vault service status returns "Sealed" = true ............ PASS [] / FAIL []
 ```
 
 </td></table>
@@ -327,14 +327,16 @@ The vault service status returns "Sealed" = true ............. PASS [] / FAIL []
 
 {{#include ../offline/unseal.md}}
 
+&nbsp;<br>
+
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The offline vault has been unsealed ......................... PASS [] / FAIL* []
+The offline vault has been unsealed ........................ PASS [] / FAIL* []
 Share holders that participated to the unseal process:
-................................................................................
-................................................................................
-................................................................................
+...............................................................................
+...............................................................................
+...............................................................................
 ```
 
 </td></table>
@@ -353,13 +355,13 @@ The 📝`reporter` communicates the list of scripts that will be run to the 👀
 
 ```report
 Scripts executed during the maintenance phase:
-................................................................................
-................................................................................
-................................................................................
-................................................................................
-................................................................................
-................................................................................
-Only the scripts initially planned have been executed ........ PASS [] / FAIL []
+...............................................................................
+...............................................................................
+...............................................................................
+...............................................................................
+...............................................................................
+...............................................................................
+Only the scripts initially planned have been executed ....... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -393,8 +395,8 @@ count-tokens
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault has been sealed .................................... PASS [] / FAIL []
-0 token exists in the vault private data before backup ....... PASS [] / FAIL []
+The vault has been sealed ................................... PASS [] / FAIL []
+0 token exists in the vault private data before backup ...... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -469,10 +471,10 @@ The value displayed should match *C<sub>vault</sub>* grabbed from the QR code ab
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data archive has been safely stored ........ PASS [] / FAIL []
-The checksum of the tar file content matches _Cvault_ ........ PASS [] / FAIL []
+The vault private data archive has been safely stored ....... PASS [] / FAIL []
+The checksum of the tar file content matches _Cvault_ ....... PASS [] / FAIL []
 Value of the full sha256 checksum of the vault private data folder (_Cvault_):
-................................................................................
+...............................................................................
 ```
 
 </td></table>

--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -181,7 +181,7 @@ For the rest of the procedure below, you can consider references to 👥`team me
 
 ```report
 Name of the organiser:
-........................................................................................
+...................................................................................
 
 Revision of the ceremony workflow used:
 @ORCA@rev@
@@ -190,51 +190,51 @@ Version (commit) of the workflow document:
 @ORCA@commit@
 
 Names of the team members that participate to the ceremony:
-Operator: ..............................................................................
-Reporter: ..............................................................................
-Observer: ..............................................................................
-These 3 roles are handled by 3 different people ...................... PASS [] / FAIL []
-These 3 people are located in the same physical room ................. PASS [] / FAIL []
+Operator: .........................................................................
+Reporter: .........................................................................
+Observer: .........................................................................
+These 3 roles are handled by 3 different people ................. PASS [] / FAIL []
+These 3 people are located in the same physical room ............ PASS [] / FAIL []
 
 Date of the ceremony:
-........................................................................................
+...................................................................................
 
 Target environment:
-................................................................... preprod [] / prod []
+.............................................................. preprod [] / prod []
 Trusted commit for the new ceremony:
-........................................................................................
+...................................................................................
 
 Date of the previous ceremony:
-........................................................................................
-Previous ceremony's trusted commit (as read in the previous ceremony's report):
-........................................................................................
-Previous ceremony's backup sha256 checksum (as read in the previous ceremony's report):
-........................................................................................
+...................................................................................
+Previous ceremony's trusted commit (as read in the previous report):
+...................................................................................
+Previous ceremony's backup sha256 checksum (as read in the previous report):
+...................................................................................
 
-The ceremony's workflow document (valid rev, digital signatures) have been checked by:
-the operator ......................................................... PASS [] / FAIL []
-the reporter ......................................................... PASS [] / FAIL []
+The ceremony's workflow document (valid rev, signatures) have been checked by:
+the operator .................................................... PASS [] / FAIL []
+the reporter .................................................... PASS [] / FAIL []
 
 The previous ceremony's report signatures have been verified by:
-the operator ........................................................ PASS [] / FAIL* []
-the reporter ........................................................ PASS [] / FAIL* []
+the operator ................................................... PASS [] / FAIL* []
+the reporter ................................................... PASS [] / FAIL* []
 
 The verifiable bytes of the iso are (value of *Niso*):
-........................................................................................
+...................................................................................
 The sha256 checksum of the *N* verifiable bytes is (value of *Ciso*):
-........................................................................................
+...................................................................................
 
 The review of changes/content of the bootable live media has been performed by:
-the operator ......................................................... PASS [] / FAIL []
-the reporter ......................................................... PASS [] / FAIL []
-All (possible) changes are legitimate ................................ PASS [] / FAIL []
+the operator .................................................... PASS [] / FAIL []
+the reporter .................................................... PASS [] / FAIL []
+All (possible) changes are legitimate ........................... PASS [] / FAIL []
 
-A bootable live media has been generated for this ceremony ........... PASS [] / FAIL []
+A bootable live media has been generated for this ceremony ...... PASS [] / FAIL []
 Identity of the team member who brings the bootable media (the key owner):
-...................................................... the operator [] / the reporter []
+................................................. the operator [] / the reporter []
 
 The offline CA private data has been restored from the following archive file:
-........................................................................................
+...................................................................................
 ```
 
 </td></table>
@@ -276,19 +276,19 @@ When booting *ephemeral vault*, a NixOS logo will appear with a boot menu mentio
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The key with the vault iso image is set as read only ................. PASS [] / FAIL []
+The key with the vault iso image is set as read only ............ PASS [] / FAIL []
 
 The operator's machine:
-can select the key as boot device .................................... PASS [] / FAIL []
-can successfully finish booting on the key while in readonly mode .... PASS [] / FAIL []
+can select the key as boot device ............................... PASS [] / FAIL []
+can successfully complete boot on the readonly key .............  PASS [] / FAIL []
 
 While performing the USB key content check on the operator's machine:
-the first partition is the only one marked as bootable ............... PASS [] / FAIL []
-the checksum *Ciso* is correct ....................................... PASS [] / FAIL []
-the computer has been powered off while the key was still read-only .. PASS [] / FAIL []
+the first partition is the only one marked as bootable .......... PASS [] / FAIL []
+the checksum *Ciso* is correct .................................. PASS [] / FAIL []
+the computer was powered off while the key was still read-only .. PASS [] / FAIL []
 
-The key for the ephemeral vault is then set as read/write and the ephemeral vault is ...
-immediately booted ................................................... PASS [] / FAIL []
+The key for the ephemeral vault is then set as read/write and the ephemeral .......
+vault is immediately booted ..................................... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -310,11 +310,11 @@ Before the very first shell prompt after booting, that computed checksum is disp
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data checksum displayed at boot (_Cvault_) matches the previous ......
-ceremony's backup sha256 checksum ................................... PASS [] / FAIL* []
-0 token exists in the vault private data at startup .................. PASS [] / FAIL []
-The vault service status returns "Initialized" = true ............... PASS [] / FAIL* []
-The vault service status returns "Sealed" = true ..................... PASS [] / FAIL []
+The vault private data checksum displayed at boot (_Cvault_) matches the ..........
+previous ceremony's backup sha256 checksum ..................... PASS [] / FAIL* []
+0 token exists in the vault private data at startup ............. PASS [] / FAIL []
+The vault service status returns "Initialized" = true .......... PASS [] / FAIL* []
+The vault service status returns "Sealed" = true ................ PASS [] / FAIL []
 ```
 
 </td></table>
@@ -329,11 +329,11 @@ The vault service status returns "Sealed" = true ..................... PASS [] /
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The offline vault has been unsealed ................................. PASS [] / FAIL* []
+The offline vault has been unsealed ............................ PASS [] / FAIL* []
 Share holders that participated to the unseal process:
-........................................................................................
-........................................................................................
-........................................................................................
+...................................................................................
+...................................................................................
+...................................................................................
 ```
 
 </td></table>
@@ -352,13 +352,13 @@ The 📝`reporter` communicates the list of scripts that will be run to the 👀
 
 ```report
 Scripts executed during the maintenance phase:
-........................................................................................
-........................................................................................
-........................................................................................
-........................................................................................
-........................................................................................
-........................................................................................
-Only the scripts initially planned have been executed ................ PASS [] / FAIL []
+...................................................................................
+...................................................................................
+...................................................................................
+...................................................................................
+...................................................................................
+...................................................................................
+Only the scripts initially planned have been executed ........... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -392,8 +392,8 @@ count-tokens
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault has been sealed ............................................ PASS [] / FAIL []
-0 token exists in the vault private data before backup ............... PASS [] / FAIL []
+The vault has been sealed ....................................... PASS [] / FAIL []
+0 token exists in the vault private data before backup .......... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -468,10 +468,10 @@ The value displayed should match *C<sub>vault</sub>* grabbed from the QR code ab
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data archive has been saved on Google Drive ........ PASS [] / FAIL []
-The checkum of the tar file content matches the checksum _Cvault_ .... PASS [] / FAIL []
+The vault private data archive has been saved on Google Drive ... PASS [] / FAIL []
+The checksum of the tar file content matches _Cvault_ ........... PASS [] / FAIL []
 Value of the full sha256 checksum of the vault private data folder (_Cvault_):
-........................................................................................
+...................................................................................
 ```
 
 </td></table>

--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -181,7 +181,7 @@ For the rest of the procedure below, you can consider references to 👥`team me
 
 ```report
 Name of the organiser:
-...................................................................................
+................................................................................
 
 Revision of the ceremony workflow used:
 @ORCA@rev@
@@ -190,51 +190,51 @@ Version (commit) of the workflow document:
 @ORCA@commit@
 
 Names of the team members that participate to the ceremony:
-Operator: .........................................................................
-Reporter: .........................................................................
-Observer: .........................................................................
-These 3 roles are handled by 3 different people ................. PASS [] / FAIL []
-These 3 people are located in the same physical room ............ PASS [] / FAIL []
+Operator: ......................................................................
+Reporter: ......................................................................
+Observer: ......................................................................
+These 3 roles are handled by 3 different people .............. PASS [] / FAIL []
+These 3 people are located in the same physical room ......... PASS [] / FAIL []
 
 Date of the ceremony:
-...................................................................................
+................................................................................
 
 Target environment:
-.............................................................. preprod [] / prod []
+........................................................... preprod [] / prod []
 Trusted commit for the new ceremony:
-...................................................................................
+................................................................................
 
 Date of the previous ceremony:
-...................................................................................
-Previous ceremony's trusted commit (as read in the previous report):
-...................................................................................
-Previous ceremony's backup sha256 checksum (as read in the previous report):
-...................................................................................
+................................................................................
+Previous trusted commit (as read from the previous ceremony's report):
+................................................................................
+Previous backup sha256 checksum (as read from the previous ceremony's report):
+................................................................................
 
 The ceremony's workflow document (valid rev, signatures) have been checked by:
-the operator .................................................... PASS [] / FAIL []
-the reporter .................................................... PASS [] / FAIL []
+the operator ................................................. PASS [] / FAIL []
+the reporter ................................................. PASS [] / FAIL []
 
 The previous ceremony's report signatures have been verified by:
-the operator ................................................... PASS [] / FAIL* []
-the reporter ................................................... PASS [] / FAIL* []
+the operator ................................................ PASS [] / FAIL* []
+the reporter ................................................ PASS [] / FAIL* []
 
 The verifiable bytes of the iso are (value of *Niso*):
-...................................................................................
+................................................................................
 The sha256 checksum of the *N* verifiable bytes is (value of *Ciso*):
-...................................................................................
+................................................................................
 
 The review of changes/content of the bootable live media has been performed by:
-the operator .................................................... PASS [] / FAIL []
-the reporter .................................................... PASS [] / FAIL []
-All (possible) changes are legitimate ........................... PASS [] / FAIL []
+the operator ................................................. PASS [] / FAIL []
+the reporter ................................................. PASS [] / FAIL []
+All (possible) changes are legitimate ........................ PASS [] / FAIL []
 
-A bootable live media has been generated for this ceremony ...... PASS [] / FAIL []
+A bootable live media has been generated for this ceremony ... PASS [] / FAIL []
 Identity of the team member who brings the bootable media (the key owner):
-................................................. the operator [] / the reporter []
+.............................................. the operator [] / the reporter []
 
 The offline CA private data has been restored from the following archive file:
-...................................................................................
+................................................................................
 ```
 
 </td></table>
@@ -276,19 +276,20 @@ When booting *ephemeral vault*, a NixOS logo will appear with a boot menu mentio
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The key with the vault iso image is set as read only ............ PASS [] / FAIL []
+The key with the vault iso image is set as read only ......... PASS [] / FAIL []
 
 The operator's machine:
-can select the key as boot device ............................... PASS [] / FAIL []
-can successfully complete boot on the readonly key .............  PASS [] / FAIL []
+can select the key as boot device ............................ PASS [] / FAIL []
+can successfully complete boot on the readonly key ..........  PASS [] / FAIL []
 
 While performing the USB key content check on the operator's machine:
-the first partition is the only one marked as bootable .......... PASS [] / FAIL []
-the checksum *Ciso* is correct .................................. PASS [] / FAIL []
-the computer was powered off while the key was still read-only .. PASS [] / FAIL []
+the first partition is the only one marked as bootable ....... PASS [] / FAIL []
+the checksum *Ciso* is correct ............................... PASS [] / FAIL []
+the computer has been powered off while the key was still read-only ............
+.............................................................. PASS [] / FAIL []
 
-The key for the ephemeral vault is then set as read/write and the ephemeral .......
-vault is immediately booted ..................................... PASS [] / FAIL []
+The key for the ephemeral vault is then set as read/write and the ephemeral ....
+vault is immediately booted .................................. PASS [] / FAIL []
 ```
 
 </td></table>
@@ -310,11 +311,11 @@ Before the very first shell prompt after booting, that computed checksum is disp
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data checksum displayed at boot (_Cvault_) matches the ..........
-previous ceremony's backup sha256 checksum ..................... PASS [] / FAIL* []
-0 token exists in the vault private data at startup ............. PASS [] / FAIL []
-The vault service status returns "Initialized" = true .......... PASS [] / FAIL* []
-The vault service status returns "Sealed" = true ................ PASS [] / FAIL []
+The vault private data checksum displayed at boot (_Cvault_) matches the .......
+previous ceremony's backup sha256 checksum .................. PASS [] / FAIL* []
+0 token exists in the vault private data at startup .......... PASS [] / FAIL []
+The vault service status returns "Initialized" = true ....... PASS [] / FAIL* []
+The vault service status returns "Sealed" = true ............. PASS [] / FAIL []
 ```
 
 </td></table>
@@ -329,11 +330,11 @@ The vault service status returns "Sealed" = true ................ PASS [] / FAIL
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The offline vault has been unsealed ............................ PASS [] / FAIL* []
+The offline vault has been unsealed ......................... PASS [] / FAIL* []
 Share holders that participated to the unseal process:
-...................................................................................
-...................................................................................
-...................................................................................
+................................................................................
+................................................................................
+................................................................................
 ```
 
 </td></table>
@@ -352,13 +353,13 @@ The 📝`reporter` communicates the list of scripts that will be run to the 👀
 
 ```report
 Scripts executed during the maintenance phase:
-...................................................................................
-...................................................................................
-...................................................................................
-...................................................................................
-...................................................................................
-...................................................................................
-Only the scripts initially planned have been executed ........... PASS [] / FAIL []
+................................................................................
+................................................................................
+................................................................................
+................................................................................
+................................................................................
+................................................................................
+Only the scripts initially planned have been executed ........ PASS [] / FAIL []
 ```
 
 </td></table>
@@ -392,8 +393,8 @@ count-tokens
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault has been sealed ....................................... PASS [] / FAIL []
-0 token exists in the vault private data before backup .......... PASS [] / FAIL []
+The vault has been sealed .................................... PASS [] / FAIL []
+0 token exists in the vault private data before backup ....... PASS [] / FAIL []
 ```
 
 </td></table>
@@ -468,10 +469,10 @@ The value displayed should match *C<sub>vault</sub>* grabbed from the QR code ab
 <table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
 
 ```report
-The vault private data archive has been saved on Google Drive ... PASS [] / FAIL []
-The checksum of the tar file content matches _Cvault_ ........... PASS [] / FAIL []
+The vault private data archive has been safely stored ........ PASS [] / FAIL []
+The checksum of the tar file content matches _Cvault_ ........ PASS [] / FAIL []
 Value of the full sha256 checksum of the vault private data folder (_Cvault_):
-...................................................................................
+................................................................................
 ```
 
 </td></table>

--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -117,12 +117,14 @@ nix build src/.#iso-offline
 
 Compute the size of the verifiable bytes (total size - 512) that we will call *N<sub>iso</sub>*:
 ```bash
-export Niso=$(expr $(stat --format=%s --dereference result/iso/orca-*.iso) - 512) && echo "Niso=$Niso"
+export Niso=$(expr $(stat --format=%s -L result/iso/orca-*.iso) - 512) && \
+ echo "Niso=$Niso"
 ```
 
 Compute a sha256 checksum *C<sub>iso</sub>* of the verifiable bytes:
 ```bash
-dd status=none if=$(command ls result/iso/orca-*.iso | head -n 1) bs=512 skip=1 | sha256sum -b | sed -E 's/^([[:xdigit:]]*).*$/Ciso=\1/'
+dd status=none if=$(command ls result/iso/orca-*.iso | head -n 1) bs=512 skip=1 | \
+ sha256sum -b | sed -E 's/^([[:xdigit:]]*).*$/Ciso=\1/'
 ```
 
 Communicate the values of *N<sub>iso</sub>* and *C<sub>iso</sub>* to the other 👥`team members`.
@@ -255,7 +257,9 @@ To check the key:
 - The following steps must be performed without booting on the USB key, with the USB key still in *read-only* mode, and directly on the installed Linux OS of the 👀`observer`'s computer.
 - An environment variable `Niso` should be set with the correct value, then the key is verified by the 👀`observer` (number of partitions, *N<sub>iso</sub>* checksum):
 ```bash
-sudo fdisk -l /dev/sda && sudo dd if=/dev/sda bs=512 skip=1 count=$(expr $Niso / 512) | sha256sum -b
+sudo fdisk -l /dev/sda && \
+ sudo dd if=/dev/sda bs=512 skip=1 count=$(expr $Niso / 512) | \
+ sha256sum -b
 ```
 - the result sha256 should match the value *C<sub>iso</sub>* computed from the ✅`trusted commit`.
 
@@ -448,7 +452,10 @@ All 👥`team members` should now:
 On both these archives, they should perform a checksum of this data with the following command:
 ```bash
 export VAULT_BACKUP=/path/to/ORCA_backup.tar
-(export TMP_DIR="$(mktemp -d)" && cd "$TMP_DIR" && sudo tar --same-owner -xf "$VAULT_BACKUP" -C . && sudo find . -type f -exec sha256sum -b {} \; | sort -k2 | sha256sum -)
+(export TMP_DIR="$(mktemp -d)" && \
+ cd "$TMP_DIR" && \
+ sudo tar --same-owner -xf "$VAULT_BACKUP" -C . && \
+ sudo find . -type f -exec sha256sum -b {} \; | sort -k2 | sha256sum -)
 ```
 
 The value displayed should match *C<sub>vault</sub>* grabbed from the QR code above.
@@ -479,9 +486,13 @@ The 📝`reporter`, 💻`operator`, and 👀`observer` will all sign the report.
 In sequence, each of them will run the following command and transfer the resulting signed file (which name is displayed on the console) to the next person:
 ```bash
 export REPORT=/path/to/IN65_report.txt
-export GPG_HW_TOKEN_KEY_ID=$(gpg --card-status | sed -n -E -e 's/^[^:]*sign[^:]*:[[:blank:]]*((:?[[:xdigit:]]{4}[[:blank:]]*){10})/\1/pi')
-sed -e '/^@GPG@SIGNATURES@$/q' "$REPORT" | gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > "$REPORT.sig.asc" && \
- cat "$REPORT" "$REPORT.sig.asc" > "$REPORT".signed && rm "$REPORT.sig.asc" && command ls "$REPORT".signed >&2
+export GPG_HW_TOKEN_KEY_ID=$(gpg --card-status | \
+ sed -n -E -e 's/^[^:]*sign[^:]*:[[:blank:]]*((:?[[:xdigit:]]{4}[[:blank:]]*){10})/\1/pi')
+sed -e '/^@GPG@SIGNATURES@$/q' "$REPORT" | \
+ gpg --armor --output - -u "$GPG_HW_TOKEN_KEY_ID" --detach-sign > "$REPORT.sig.asc" && \
+ cat "$REPORT" "$REPORT.sig.asc" > "$REPORT".signed && \
+ rm "$REPORT.sig.asc" && \
+ command ls "$REPORT".signed >&2
 ```
 > [!Note]  
 > In the shell snippet above, we catch the hardware token public key ID from the signing key ID in the token, and store this inside variable `GPG_HW_TOKEN_KEY_ID`.  

--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -303,6 +303,8 @@ In order to be sure that offline private data has not been tampered with (or dow
 
 Before the very first shell prompt after booting, that computed checksum is displayed on the screen, as well as the existing root token count (that should be 0) and the vault status.
 
+<table width=100% style="border:2px dotted dodgerblue;"><td style="padding:0;">
+
 ```report
 The vault private data checksum displayed at boot (_Cvault_) matches the previous ......
 ceremony's backup sha256 checksum ................................... PASS [] / FAIL* []
@@ -310,6 +312,8 @@ ceremony's backup sha256 checksum ................................... PASS [] / 
 The vault service status returns "Initialized" = true ............... PASS [] / FAIL* []
 The vault service status returns "Sealed" = true ..................... PASS [] / FAIL []
 ```
+
+</td></table>
 
 ### Unsealing the *ephemeral vault*
 


### PR DESCRIPTION
## How it was done

This PR contains various fixes for scripts and layout in the documentation.
It also rewrites pre-formatted output so that most sample commands fit on one file or at least have a continuation backslack at the end, so that even copying/pasting commands from a PDF version should work (split multi-lines in a PDF verison of the doc will result in a carriage return to be inserted at the end of each line). 
