### PR TITLE
Adding prod/preprod check by team members

### DIFF
--- a/docs/workflow/offline_vault_ceremony.md
+++ b/docs/workflow/offline_vault_ceremony.md
@@ -80,7 +80,7 @@ The 📢`organiser` asks all `share holders` (including 👥`team members`) to c
 
 #### Setting up the trusted commit
 
-When all scripts planned for the ceremony are ready and all keys are up-to-date, the 📢`organiser` writes down the last git commit of repo [O.R.CA]@ORCA@gitremote@) containing all re-inserted keys, and communicates this commit to all 👥`team members`.
+When all scripts planned for the ceremony are ready and all keys are up-to-date, the 📢`organiser` writes down the last git commit of repo [O.R.CA](@ORCA@gitremote@) containing all re-inserted keys, and communicates this commit to all 👥`team members`.
 
 For the rest of this documentation, we are going to name that commit the `trusted commit` (✅)
 
@@ -122,11 +122,12 @@ git diff <previous ceremony trusted commit> src/
 ```
 
 > [!Important]  
-> All content within `src/` should only reference files also within `src/`.\
-> Any change displayed by the diff should be considered legitimate to you.\
-> During this step, 👥`team members` will also review and understand all the scripts that are planned for execution during the ceremony.
-> Scripts should never ask the offline topmost root CA to sign anything that doesn't strictly remains in the offline vault (no external CSR).
-> If the offline CA is signing a CSR from a third party (for example online) CA, the authenticity of the CSR file should be checked. Please consult your online PKI documentation to know how to authentify the emitter of the CSR.
+> * The environment (prod/preprod) that has been [selected when organising the ceremony](#selecting-the-vault-environment) should be verified.
+> * All content within `src/` should only reference files also within `src/`.
+> * Any change displayed by the diff should be considered legitimate to you.
+> * During this step, 👥`team members` will also review and understand all the scripts that are planned for execution during the ceremony.
+> * Scripts should never ask the offline topmost root CA to sign anything that doesn't strictly remains in the offline vault (no external CSR).
+> * If the offline CA is signing a CSR from a third party (for example online) CA, the authenticity of the CSR file should be checked. Please consult your online PKI documentation to know how to authentify the emitter of the CSR.
 
 Once all 👥`team members` have validated the new ✅`trusted commit`, each of them will gather some fingerprinting data concerning the bootable media that will be used during the ceremony:
 


### PR DESCRIPTION
## What needs to be changed

By default, when generating the USB ISO image, the correct environment (prod/preprod) should be setup.
This is expected to happen when preparing the ceremony by the organiser see [here](https://github.com/eove/orca/blob/900bbb9bd112ef8226bd7e556dc0d8d0202ea970/docs/workflow/offline_vault_ceremony.md#selecting-the-vault-environment).
This may however be overlooked and team members may not even see this come out as a difference compared to the previous ceremony.
If the organiser fails to properly update the environment, share holder keys and shares will not be populated accordingly and the ceremony will fail when unsealing the vault (because the vault private data should be, instead, picked from the correct environment).
Because the ceremony will fail, nothing serious will happen, but this would waste the team's time, so we'd double-check the environment earlier.

## How it was done

Before the ISO image is generated (when team members check the differences highlighted for the ceremony to come), we add a dedicated check on the correct environment. If team members are unsure, they should ask the organiser, but they should already be aware of the environment against which the ceremony is going to be run.