### PR TITLE
Require the backup to create the stick when cvault is not null

### DIFF
--- a/example/docs/offline_vault_ceremony.md
+++ b/example/docs/offline_vault_ceremony.md
@@ -189,8 +189,14 @@ In order to create this bootable live media, that we will refer to as *ephemeral
 > [!Warning]  
 > Make sure you are doing this on the ✅`trusted commit`
 
+When initializing the vault :
 ```bash
 nix run . /dev/sda
+```
+
+Otherwise, fetch the offline CA private data backup for the corresponding environment (eg: prod, preprod etc.) and run :
+```bash
+nix run . /dev/sda /path/to/ORCA_backup.tar
 ```
 
 > [!Warning]  
@@ -202,33 +208,8 @@ By default, this script will create 3 partitions on the *ephemeral vault* media,
 
 You can check that with :
 ```bash
-lsblk -o name,label
+lsblk -o name,label /dev/sda
 ```
-
-> [!Warning]  
-> The rest of this section should not be executed at the first initialisation of the vault because we have no previous backup. In that case, please skip to the next section.
-
-Fetch offline CA private data backup for the corresponding environment (eg: prod, preprod etc.).
-
-The content of the previous offline vault private data should be extracted and put into the `VAULT_WRITABLE` partition.
-
-If the USB stick's partitions have been mounted automatically by your distro, the following will help in finding out the mount point for the `VAULT_WRITABLE` content:
-```bash
-lsblk -o name,mountpoint,label,size | grep VAULT_WRITABLE
-```
-
-If the above fails, then you will have to mount the `VAULT_WRITABLE` partition (manually on the CLI or by opening the volume in your file manager).  
-In the examples below, we use `/VAULT_WRITABLE/mount/point` as the mount point.
-
-You can extract the tar archive of the vault private data with:
-```bash
-sudo tar --same-owner -xvf ORCA_backup.tar -C /VAULT_WRITABLE/mount/point
-```
-
-> [!Tip]  
-> You can double-check that the data is correct with:  
-> `cd /VAULT_WRITABLE/mount/point && sudo find . -type f -exec sha256sum -b {} \; | sort -k2 | sha256sum -`  
-> You should get the same checksum as the value *C<sub>vault</sub>* indicated in the `previous report`.
 
 ## Executing the ceremony
 

--- a/src/create-stick.nix
+++ b/src/create-stick.nix
@@ -1,12 +1,14 @@
-{ isoImage, pkgs, ORCA_DISK_NAME, ... }:
+{ isoImage, pkgs, ORCA_DISK_NAME, orca_config, ... }:
 let
+  cvault = orca_config.latest_cvault;
+  is_init = cvault == null;
   rootUsbScript = pkgs.writeShellScriptBin "root-iso-to-usb" ''
     set -e
     TARGET_DEVICE="$1"
     function force_unmount(){
       for MOUNTED in $(${pkgs.util-linux}/bin/lsblk -n -o MOUNTPOINTS $TARGET_DEVICE)
       do
-        umount "$MOUNTED"
+        ${pkgs.lib.getExe pkgs.umount} "$MOUNTED"
       done
     }
     force_unmount
@@ -19,21 +21,46 @@ let
     sleep 2
     force_unmount
     ${pkgs.e2fsprogs}/bin/mkfs.ext4 -F -L "${ORCA_DISK_NAME}" ''${TARGET_DEVICE}3
+    force_unmount
+    ${if !is_init then ''
+    BACKUP="$2"
+    MOUNT_POINT=$(${pkgs.lib.getExe pkgs.mktemp} -d)
+    ${pkgs.lib.getExe pkgs.mount} ''${TARGET_DEVICE}3 $MOUNT_POINT
+    tar --same-owner -xf "$BACKUP" -C $MOUNT_POINT
+    CVAULT=$(cd $MOUNT_POINT && find . -type f -exec sha256sum -b {} \; | sort -k2 | sha256sum - | cut -d " " -f 1 )
+    force_unmount
+    if [ "$CVAULT" != "${pkgs.lib.toLower cvault}" ]; then
+      echo "$BACKUP has a cvault of $CVAULT but we expected ${cvault}" >&2
+      exit -2
+    fi
+    '' else ""}
+    echo "The stick is ready to be used for a ceremony. You should switch it to read-only."
   '';
   usbScript = pkgs.writeShellScriptBin "iso-to-usb" ''
     set -e
-    if [ "$#" -ne 1 ]; then
+    ${if is_init then 
+    ''if [ "$#" -ne 1 ]; then
       echo "Usage : $0 /dev/selected_mass_storage" >&2
       echo "with /dev/selected_mass_storage being the raw device (and not a partition) for a USB stick on which to install the vault live image" >&2
       exit -1
-    fi
+    fi'' else
+    ''if [ "$#" -ne 2 ]; then
+      echo "Usage : $0 /dev/selected_mass_storage /path/to/ORCA_backup.tar" >&2
+      echo "with /dev/selected_mass_storage being the raw device (and not a partition) for a USB stick on which to install the vault live image" >&2
+      echo "and /path/to/ORCA_backup.tar the path to the backup to restore" >&2
+      exit -1
+    fi''
+    }
     KEY="$1"
     if [ "$(<''${KEY/dev/sys\/block}/removable)" != "1" ]; then
       echo "Error : $KEY is not removable." >&2
       exit -2
     fi
+    BACKUP="$2"
 
-    sudo ${pkgs.lib.getExe rootUsbScript} $KEY
+    echo "We need to become root in order to format $KEY"
+
+    sudo ${pkgs.lib.getExe rootUsbScript} "$KEY" "$BACKUP"
   '';
 in
 {

--- a/src/lib.nix
+++ b/src/lib.nix
@@ -1,6 +1,6 @@
 { self, ... }@args:
 rec {
   create-iso = orca_config: import ./orca-iso.nix (args // { inherit orca_config; });
-  create-stick = orca_config: import ./create-stick.nix (args // { isoImage = create-iso orca_config; });
+  create-stick = orca_config: import ./create-stick.nix (args // { isoImage = create-iso orca_config; inherit orca_config; });
   run-in-vm = orca_config: import ./run-in-vm.nix (args // { inherit orca_config; });
 }


### PR DESCRIPTION
## How it was done

- Require the backup file when cvault is not null
- Untar the archive when necessary
- Check that the result match the configure cvault
- Update documentation accordingly