### PR TITLE
Use /crl/pem instead of /crl/der to fetch CRLs

### DIFF
--- a/example/actions/revoke-certificate.sh
+++ b/example/actions/revoke-certificate.sh
@@ -30,4 +30,7 @@ vault write ${PKI_NAME}/revoke \
 
 CRL_DIR="$AIA_FOLDER/$PKI_NAME/issuer/$ISSUER_ID/crl"
 mkdir -p $CRL_DIR
-vault read -format=raw $PKI_NAME/issuer/$ISSUER_ID/crl/der > $CRL_DIR/der
+# We use `/crl/pem` instead of `/crl/der`, as the latter seems to show inconsistent behavior in its output, see https://github.com/hashicorp/vault/issues/32018
+vault read -format=raw $PKI_NAME/issuer/$ISSUER_ID/crl/pem > $CRL_DIR/pem
+openssl crl -outform der -in $CRL_DIR/pem -out $CRL_DIR/der
+rm $CRL_DIR/pem

--- a/src/scripts/orca-protocol/sudoer/export_crls.nix
+++ b/src/scripts/orca-protocol/sudoer/export_crls.nix
@@ -19,7 +19,10 @@ in
               CRL_DIR="$PKI_AIA_DIR/crl"
               mkdir -p $CRL_DIR
               vault read -format=raw ''${PKI_NAME}/issuer/$ISSUER_ID/der > $PKI_AIA_DIR/der
-              vault read -format=raw ''${PKI_NAME}/issuer/$ISSUER_ID/crl/der > $CRL_DIR/der
+              # We use `/crl/pem` instead of `/crl/der`, as the latter seems to show inconsistent behavior in its output, see https://github.com/hashicorp/vault/issues/32018
+              vault read -format=raw ''${PKI_NAME}/issuer/$ISSUER_ID/crl/pem > $CRL_DIR/pem
+              openssl crl -outform der -in $CRL_DIR/pem -out $CRL_DIR/der
+              rm $CRL_DIR/pem
           fi
       done
   done


### PR DESCRIPTION
As a (hopefully) temporary fix to https://github.com/hashicorp/vault/issues/32018

Won't merge for now, to give some time on the original ticket.